### PR TITLE
Add support for resized images

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ const converter = new showdown.Converter({
   simpleLineBreaks: true,
   ghMentions: true,
   tables: true,
-  emoji: true
+  emoji: true,
+  parseImgDimensions: true
 });
 
 converter.setFlavor('github');


### PR DESCRIPTION
Since many images in READMEs are resized, I propose to enable the `parseImgDimensions` showdown option.