### PR TITLE
Fix #5 - windows line endings break yarn usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,4 @@ root = true
 indent_style = space
 indent_size = 2
 charset = utf-8
+end_of_line = LF

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-readme-to-html",
-  "version": "1.0.7-beta.0",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-readme-to-html",
-  "version": "1.0.6",
+  "version": "1.0.7-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-readme-to-html",
-  "version": "1.0.6",
+  "version": "1.0.7-beta.0",
   "description": "Generate a simple HTML page based on a single markdown file",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-readme-to-html",
-  "version": "1.0.7-beta.0",
+  "version": "1.0.7",
   "description": "Generate a simple HTML page based on a single markdown file",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Follow the suggestions in https://github.com/yarnpkg/yarn/issues/5480

- establish .editorconfig setting to ensure LF is used by editor
- establish .gitattributes setting to ensure LF is used upon checkout
